### PR TITLE
Remove implied '+'

### DIFF
--- a/custom-weather-card-chart.js
+++ b/custom-weather-card-chart.js
@@ -165,9 +165,6 @@ class WeatherCardChart extends Polymer.Element {
   }
 
   computeTemp(temperature) {
-    if (temperature > 0) {
-      return "+" + Math.round(temperature);
-    }
     return Math.round(temperature)
   }
 
@@ -331,9 +328,6 @@ class WeatherCardChart extends Polymer.Element {
               display: true,
               fontColor: textColor,
               callback: function(value, index, values) {
-                if (value > 0) {
-                  return '+' + value;
-                }
                 return value;
               }
             },


### PR DESCRIPTION
Didn't personally like the look of the `+` in front of the current temperature and tick marks, not sure if that is standard elsewhere or not. If so, perhaps it could be an option?