### PR TITLE
Add chartOnly mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ custom_updater:
 
 #### Configuration variables:
 
-| Name    | Optional | Description                                                                                        |
-| ------- | -------- | -------------------------------------------------------------------------------------------------- |
-| type    | **No**   | Should be `'custom:weather-card-chart'`                                                            |
-| title   | **No**   | Card title                                                                                         |
-| weather | **No**   | An entity_id with the `weather` domain                                                             |
-| temp    | Yes      | Entity_id of the temperature sensor. Show temperature value from sensor instead                    |
-| mode    | Yes      | Default value: `daily`. Set mode to `hourly` to display hours instead weekdays on the chart        |
+| Name      | Optional | Description                                                                                        |
+| --------- | -------- | -------------------------------------------------------------------------------------------------- |
+| type      | **No**   | Should be `'custom:weather-card-chart'`                                                            |
+| title     | **No**   | Card title                                                                                         |
+| weather   | **No**   | An entity_id with the `weather` domain                                                             |
+| temp      | Yes      | Entity_id of the temperature sensor. Show temperature value from sensor instead                    |
+| mode      | Yes      | Default value: `daily`. Set mode to `hourly` to display hours instead weekdays on the chart        |
+| chartOnly | Yes      | Hides the current conditions to only display the temperature/precipitation chart itself            |

--- a/custom-weather-card-chart.js
+++ b/custom-weather-card-chart.js
@@ -119,10 +119,13 @@ class WeatherCardChart extends Polymer.Element {
           align-items: center;
           margin: 0px 3px 0px 16px;
         }
+        [hidden] {
+          display: none !important;
+        }
       </style>
       <ha-card header="[[title]]">
         <div class="card">
-          <div class="main">
+          <div class="main" hidden="[[chartOnly]]">
             <ha-icon icon="[[getWeatherIcon(weatherObj.state)]]"></ha-icon>
             <template is="dom-if" if="[[tempObj]]">
               <div on-click="_tempAttr">[[roundNumber(tempObj.state)]]<sup>[[getUnit('temperature')]]</sup></div>
@@ -131,7 +134,7 @@ class WeatherCardChart extends Polymer.Element {
               <div on-click="_weatherAttr">[[roundNumber(weatherObj.attributes.temperature)]]<sup>[[getUnit('temperature')]]</sup></div>
             </template>
           </div>
-          <div class="attributes" on-click="_weatherAttr">
+          <div class="attributes" on-click="_weatherAttr" hidden="[[chartOnly]]">
             <div>
               <ha-icon icon="hass:water-percent"></ha-icon> [[roundNumber(weatherObj.attributes.humidity)]] %<br>
               <ha-icon icon="hass:gauge"></ha-icon> [[roundNumber(weatherObj.attributes.pressure)]] [[ll('uPress')]]
@@ -166,6 +169,7 @@ class WeatherCardChart extends Polymer.Element {
       sunObj: Object,
       tempObj: Object,
       mode: String,
+      this.chartOnly = config.chartOnly;
       weatherObj: {
         type: Object,
         observer: 'dataChanged',


### PR DESCRIPTION
Example of usage (I left the title blank in the second card so it would really only show the chart. Might needs updating the documentation to say that `title` can be empty.)
![Screenshot_2019-05-12_20-02-26](https://user-images.githubusercontent.com/729588/57598467-e0b8a780-7542-11e9-9b3c-eb271d2fefc1.png)
