### PR TITLE
Improve visibility of horizontal grid lines

### DIFF
--- a/custom-weather-card-chart.js
+++ b/custom-weather-card-chart.js
@@ -398,7 +398,7 @@ class WeatherCardChart extends Polymer.Element {
               display: true,
               drawBorder: false,
               color: dividerColor,
-              borderDash: [1,3],
+              borderDash: [4,6],
             },
             ticks: {
               display: true,


### PR DESCRIPTION
It might depend on the screen settings, but on none of my devices I would easily make out the horizontal grid lines. This change makes them much more visible but still not intrusive.